### PR TITLE
support optimism blob

### DIFF
--- a/contracts/BlobStorageManager.sol
+++ b/contracts/BlobStorageManager.sol
@@ -5,7 +5,8 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 enum DecodeType {
     RawData,
-    PaddingPer31Bytes
+    PaddingPer31Bytes,
+    OptimismCompact
 }
 
 interface IEthStorageContract {
@@ -84,7 +85,7 @@ contract BlobStorageManager is Ownable {
             return (new bytes(0), false);
         }
 
-        bytes memory data = storageContract.get(keyToChunks[key][chunkId], DecodeType.PaddingPer31Bytes, 0, length);
+        bytes memory data = storageContract.get(keyToChunks[key][chunkId], DecodeType.OptimismCompact, 0, length);
         return (data, true);
     }
 
@@ -99,7 +100,7 @@ contract BlobStorageManager is Ownable {
         for (uint256 chunkId = 0; chunkId < chunkNum; chunkId++) {
             bytes32 chunkKey = keyToChunks[key][chunkId];
             uint256 length = storageContract.size(chunkKey);
-            storageContract.get(chunkKey, DecodeType.PaddingPer31Bytes, 0, length);
+            storageContract.get(chunkKey, DecodeType.OptimismCompact, 0, length);
 
             assembly {
                 returndatacopy(add(add(concatenatedData, offset), 0x20), 0x40, length)

--- a/contracts/ERC5018.sol
+++ b/contracts/ERC5018.sol
@@ -7,8 +7,6 @@ import "./BlobStorageManager.sol";
 
 contract ERC5018 is IERC5018, LargeStorageManager, BlobStorageManager {
 
-    string public constant version = "1.0.0";
-
     enum StorageMode {
         Uninitialized,
         OnChain,
@@ -21,6 +19,12 @@ contract ERC5018 is IERC5018, LargeStorageManager, BlobStorageManager {
         uint32 maxChunkSize,
         address storageAddress
     ) LargeStorageManager(slotLimit) BlobStorageManager(maxChunkSize, storageAddress) {}
+
+    /// @notice Semantic version.
+    /// @custom:semver 1.0.0
+    function version() public pure virtual returns (string memory) {
+        return "1.0.0";
+    }
 
     function getStorageMode(bytes memory name) public view returns (StorageMode) {
         return storageModes[keccak256(name)];

--- a/contracts/ERC5018.sol
+++ b/contracts/ERC5018.sol
@@ -7,6 +7,8 @@ import "./BlobStorageManager.sol";
 
 contract ERC5018 is IERC5018, LargeStorageManager, BlobStorageManager {
 
+    string public constant version = "1.0.0";
+
     enum StorageMode {
         Uninitialized,
         OnChain,

--- a/contracts/ERC5018.sol
+++ b/contracts/ERC5018.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.0;
 import "./IERC5018.sol";
 import "./LargeStorageManager.sol";
 import "./BlobStorageManager.sol";
+import "./ISemver.sol";
 
-contract ERC5018 is IERC5018, LargeStorageManager, BlobStorageManager {
+contract ERC5018 is LargeStorageManager, BlobStorageManager, IERC5018, ISemver {
 
     enum StorageMode {
         Uninitialized,

--- a/contracts/ISemver.sol
+++ b/contracts/ISemver.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title ISemver
+/// @notice ISemver is a simple contract for ensuring that contracts are
+///         versioned using semantic versioning.
+interface ISemver {
+    /// @notice Getter for the semantic version of the contract. This is not
+    ///         meant to be used onchain but instead meant to be used by offchain
+    ///         tooling.
+    /// @return Semver contract version as a string.
+    function version() external view returns (string memory);
+}


### PR DESCRIPTION
Since the Optimism Blob can carry more content than the standard Blob, it is necessary to convert the standard Blob to an Optimism Blob.
Additionally, to ensure the SDK remains backward compatible and adaptable to the current live version, a `version` field should be added for differentiation. This is necessary because the current live version of the SDK will continue to use the standard Blob for uploading and downloading.