### PR TITLE
Supports batch acquisition of hashes

### DIFF
--- a/contracts/BlobStorageManager.sol
+++ b/contracts/BlobStorageManager.sol
@@ -52,11 +52,7 @@ contract BlobStorageManager is Ownable {
 
     function _countChunksFromBlob(bytes32 key) internal view returns (uint256) {
         uint256 chunkId = 0;
-        while (true) {
-            bytes32 chunkKey = keyToChunks[key][chunkId];
-            if (chunkKey == bytes32(0)) {
-                break;
-            }
+        while (keyToChunks[key][chunkId] != bytes32(0)) {
             chunkId++;
         }
         return chunkId;
@@ -112,8 +108,7 @@ contract BlobStorageManager is Ownable {
     }
 
     function _removeChunkFromBlob(bytes32 key, uint256 chunkId) internal returns (bool) {
-        bytes32 chunkKey = keyToChunks[key][chunkId];
-        if (chunkKey == bytes32(0)) {
+        if (keyToChunks[key][chunkId] == bytes32(0)) {
             return false;
         }
         if (keyToChunks[key][chunkId + 1] != bytes32(0)) {
@@ -128,12 +123,7 @@ contract BlobStorageManager is Ownable {
     }
 
     function _removeFromBlob(bytes32 key, uint256 chunkId) internal returns (uint256) {
-        while (true) {
-            bytes32 chunkKey = keyToChunks[key][chunkId];
-            if (chunkKey == bytes32(0)) {
-                break;
-            }
-
+        while (keyToChunks[key][chunkId] != bytes32(0)) {
             // TODO The current version does not support the delete
             // storageContract.remove(keyToChunks[key][chunkId]);
             keyToChunks[key][chunkId] = bytes32(0);
@@ -143,8 +133,7 @@ contract BlobStorageManager is Ownable {
     }
 
     function _preparePutFromBlob(bytes32 key, uint256 chunkId) private {
-        bytes32 chunkKey = keyToChunks[key][chunkId];
-        if (chunkKey == bytes32(0)) {
+        if (keyToChunks[key][chunkId] == bytes32(0)) {
             require(chunkId == 0 || keyToChunks[key][chunkId - 1] != bytes32(0), "must replace or append");
         } else {
             // TODO The current version does not support the delete

--- a/contracts/ERC5018.sol
+++ b/contracts/ERC5018.sol
@@ -169,7 +169,7 @@ contract ERC5018 is LargeStorageManager, BlobStorageManager, IERC5018, ISemver {
         return 0;
     }
 
-    function getChunkHashes(bytes memory name, uint256[] memory chunkIds) public override view returns (bytes32[] memory hashes) {
+    function getChunkHashes(bytes memory name, uint256[] memory chunkIds) public view returns (bytes32[] memory hashes) {
         bytes32 key = keccak256(name);
         StorageMode mode = storageModes[key];
 
@@ -182,5 +182,20 @@ contract ERC5018 is LargeStorageManager, BlobStorageManager, IERC5018, ISemver {
                 hashes[i] = keccak256(localData);
             }
         }
+    }
+
+    function getUploadInfo(bytes memory name) public view returns (StorageMode mode, uint256 count, uint256 payment) {
+        bytes32 key = keccak256(name);
+        mode = storageModes[key];
+
+        if (mode == StorageMode.Blob) {
+            count = _countChunksFromBlob(key);
+        } else if (mode == StorageMode.OnChain) {
+            count = _countChunks(key);
+        } else {
+            count = 0;
+        }
+
+        payment = address(storageContract) != address(0) ? upfrontPayment() : 0;
     }
 }

--- a/contracts/ERC5018.sol
+++ b/contracts/ERC5018.sol
@@ -161,4 +161,19 @@ contract ERC5018 is IERC5018, LargeStorageManager, BlobStorageManager {
         }
         return 0;
     }
+
+    function getChunkHashes(bytes memory name, uint256[] memory chunkIds) public override view returns (bytes32[] memory hashes) {
+        bytes32 key = keccak256(name);
+        StorageMode mode = storageModes[key];
+
+        hashes = new bytes32[](chunkIds.length);
+        for (uint8 i = 0; i < chunkIds.length; i++) {
+            if (mode == StorageMode.Blob) {
+                hashes[i] = _getChunkHashFromBlob(key, chunkIds[i]);
+            } else if (mode == StorageMode.OnChain) {
+                (bytes memory localData,) = _getChunk(key, chunkIds[i]);
+                hashes[i] = keccak256(localData);
+            }
+        }
+    }
 }

--- a/contracts/ERC5018.sol
+++ b/contracts/ERC5018.sol
@@ -172,12 +172,22 @@ contract ERC5018 is LargeStorageManager, BlobStorageManager, IERC5018, ISemver {
         return 0;
     }
 
-    function getChunkHashes(bytes[] memory names, uint256[] memory chunkIds) public override view returns (bytes32[] memory hashes) {
-        require(names.length == chunkIds.length, "Invalid length");
-        hashes = new bytes32[](names.length);
-        for (uint8 i = 0; i < names.length; i++) {
-            hashes[i] = getChunkHash(names[i], chunkIds[i]);
+    function getBatchChunkHashes(FileChunk[] memory fileChunks) external view returns (bytes32[] memory) {
+        uint totalChunks = 0;
+
+        for (uint i = 0; i < fileChunks.length; i++) {
+            totalChunks += fileChunks[i].chunkIds.length;
         }
+
+        bytes32[] memory hashes = new bytes32[](totalChunks);
+        uint index = 0;
+        for (uint i = 0; i < fileChunks.length; i++) {
+            for (uint j = 0; j < fileChunks[i].chunkIds.length; j++) {
+                hashes[index] = getChunkHash(fileChunks[i].name, fileChunks[i].chunkIds[j]);
+                index++;
+            }
+        }
+        return hashes;
     }
 
     function getUploadInfo(bytes memory name) public override view returns (StorageMode mode, uint256 count, uint256 payment) {

--- a/contracts/ERC5018.sol
+++ b/contracts/ERC5018.sol
@@ -8,11 +8,6 @@ import "./ISemver.sol";
 
 contract ERC5018 is LargeStorageManager, BlobStorageManager, IERC5018, ISemver {
 
-    enum StorageMode {
-        Uninitialized,
-        OnChain,
-        Blob
-    }
     mapping(bytes32 => StorageMode) storageModes;
 
     constructor(
@@ -192,7 +187,7 @@ contract ERC5018 is LargeStorageManager, BlobStorageManager, IERC5018, ISemver {
         }
     }
 
-    function getUploadInfo(bytes memory name) public view returns (StorageMode mode, uint256 count, uint256 payment) {
+    function getUploadInfo(bytes memory name) public override view returns (StorageMode mode, uint256 count, uint256 payment) {
         bytes32 key = keccak256(name);
         mode = storageModes[key];
 

--- a/contracts/ERC5018.sol
+++ b/contracts/ERC5018.sol
@@ -187,7 +187,7 @@ contract ERC5018 is LargeStorageManager, BlobStorageManager, IERC5018, ISemver {
         return counts;
     }
 
-    function getUploadDetails(bytes memory name) public override view returns (StorageMode mode, uint256 chunkCount, uint256 storageCost) {
+    function getUploadInfo(bytes memory name) public override view returns (StorageMode mode, uint256 chunkCount, uint256 storageCost) {
         bytes32 key;
         (key, mode) = _getModeAndKey(name);
 

--- a/contracts/ERC5018.sol
+++ b/contracts/ERC5018.sol
@@ -172,18 +172,11 @@ contract ERC5018 is LargeStorageManager, BlobStorageManager, IERC5018, ISemver {
         return 0;
     }
 
-    function getChunkHashes(bytes memory name, uint256[] memory chunkIds) public override view returns (bytes32[] memory hashes) {
-        bytes32 key = keccak256(name);
-        StorageMode mode = storageModes[key];
-
-        hashes = new bytes32[](chunkIds.length);
-        for (uint8 i = 0; i < chunkIds.length; i++) {
-            if (mode == StorageMode.Blob) {
-                hashes[i] = _getChunkHashFromBlob(key, chunkIds[i]);
-            } else if (mode == StorageMode.OnChain) {
-                (bytes memory localData,) = _getChunk(key, chunkIds[i]);
-                hashes[i] = keccak256(localData);
-            }
+    function getChunkHashes(bytes[] memory names, uint256[] memory chunkIds) public override view returns (bytes32[] memory hashes) {
+        require(names.length == chunkIds.length, "Invalid length");
+        hashes = new bytes32[](names.length);
+        for (uint8 i = 0; i < names.length; i++) {
+            hashes[i] = getChunkHash(names[i], chunkIds[i]);
         }
     }
 

--- a/contracts/IERC5018.sol
+++ b/contracts/IERC5018.sol
@@ -48,7 +48,9 @@ interface IERC5018 {
 
     function getChunkHash(bytes memory name, uint256 chunkId) external view returns (bytes32);
 
-    function getBatchChunkHashes(FileChunk[] memory fileChunks) external view returns (bytes32[] memory);
+    function getChunkHashesBatch(FileChunk[] memory fileChunks) external view returns (bytes32[] memory);
 
-    function getUploadInfo(bytes memory name) external view returns (StorageMode mode, uint256 count, uint256 payment);
+    function getChunkCountsBatch(bytes[] memory names) external view returns (uint256[] memory);
+
+    function getUploadDetails(bytes memory name) external view returns (StorageMode mode, uint256 chunkCount, uint256 storageCost);
 }

--- a/contracts/IERC5018.sol
+++ b/contracts/IERC5018.sol
@@ -2,6 +2,12 @@
 pragma solidity ^0.8.0;
 
 interface IERC5018 {
+    enum StorageMode {
+        Uninitialized,
+        OnChain,
+        Blob
+    }
+
     // Large storage methods
     function write(bytes memory name, bytes memory data) external payable;
 
@@ -36,4 +42,8 @@ interface IERC5018 {
     function destruct() external;
 
     function getChunkHash(bytes memory name, uint256 chunkId) external view returns (bytes32);
+
+    function getChunkHashes(bytes memory name, uint256[] memory chunkIds) external view returns (bytes32[] memory hashes);
+
+    function getUploadInfo(bytes memory name) external view returns (StorageMode mode, uint256 count, uint256 payment);
 }

--- a/contracts/IERC5018.sol
+++ b/contracts/IERC5018.sol
@@ -8,6 +8,11 @@ interface IERC5018 {
         Blob
     }
 
+    struct FileChunk {
+        bytes name;
+        uint256[] chunkIds;
+    }
+
     // Large storage methods
     function write(bytes memory name, bytes memory data) external payable;
 
@@ -43,7 +48,7 @@ interface IERC5018 {
 
     function getChunkHash(bytes memory name, uint256 chunkId) external view returns (bytes32);
 
-    function getChunkHashes(bytes[] memory names, uint256[] memory chunkIds) external view returns (bytes32[] memory hashes);
+    function getBatchChunkHashes(FileChunk[] memory fileChunks) external view returns (bytes32[] memory);
 
     function getUploadInfo(bytes memory name) external view returns (StorageMode mode, uint256 count, uint256 payment);
 }

--- a/contracts/IERC5018.sol
+++ b/contracts/IERC5018.sol
@@ -43,7 +43,7 @@ interface IERC5018 {
 
     function getChunkHash(bytes memory name, uint256 chunkId) external view returns (bytes32);
 
-    function getChunkHashes(bytes memory name, uint256[] memory chunkIds) external view returns (bytes32[] memory hashes);
+    function getChunkHashes(bytes[] memory names, uint256[] memory chunkIds) external view returns (bytes32[] memory hashes);
 
     function getUploadInfo(bytes memory name) external view returns (StorageMode mode, uint256 count, uint256 payment);
 }

--- a/contracts/IERC5018.sol
+++ b/contracts/IERC5018.sol
@@ -52,5 +52,5 @@ interface IERC5018 {
 
     function getChunkCountsBatch(bytes[] memory names) external view returns (uint256[] memory);
 
-    function getUploadDetails(bytes memory name) external view returns (StorageMode mode, uint256 chunkCount, uint256 storageCost);
+    function getUploadInfo(bytes memory name) external view returns (StorageMode mode, uint256 chunkCount, uint256 storageCost);
 }

--- a/contracts/LargeStorageManager.sol
+++ b/contracts/LargeStorageManager.sol
@@ -75,11 +75,9 @@ contract LargeStorageManager {
         bytes32 metadata = keyToMetadata[key][chunkId];
 
         if (metadata.isInSlot()) {
-            bytes memory res = SlotHelper.getRaw(keyToSlots[key][chunkId], metadata);
-            return (res, true);
+            return (SlotHelper.getRaw(keyToSlots[key][chunkId], metadata), true);
         } else {
-            address addr = metadata.bytes32ToAddr();
-            return StorageHelper.getRaw(addr);
+            return StorageHelper.getRaw(metadata.bytes32ToAddr());
         }
     }
 
@@ -89,23 +87,16 @@ contract LargeStorageManager {
         if (metadata == bytes32(0)) {
             return (0, false);
         } else if (metadata.isInSlot()) {
-            uint256 len = metadata.decodeLen();
-            return (len, true);
+            return (metadata.decodeLen(), true);
         } else {
-            address addr = metadata.bytes32ToAddr();
-            return StorageHelper.sizeRaw(addr);
+            return StorageHelper.sizeRaw(metadata.bytes32ToAddr());
         }
     }
 
     function _countChunks(bytes32 key) internal view returns (uint256) {
         uint256 chunkId = 0;
 
-        while (true) {
-            bytes32 metadata = keyToMetadata[key][chunkId];
-            if (metadata == bytes32(0x0)) {
-                break;
-            }
-
+        while (keyToMetadata[key][chunkId] != bytes32(0)) {
             chunkId++;
         }
 
@@ -162,11 +153,8 @@ contract LargeStorageManager {
 
     // Returns # of chunks deleted
     function _remove(bytes32 key, uint256 chunkId) internal returns (uint256) {
-        while (true) {
+        while (keyToMetadata[key][chunkId] != bytes32(0)) {
             bytes32 metadata = keyToMetadata[key][chunkId];
-            if (metadata == bytes32(0x0)) {
-                break;
-            }
 
             if (!metadata.isInSlot()) {
                 address addr = metadata.bytes32ToAddr();


### PR DESCRIPTION
Implement this [issue](https://github.com/ethstorage/ethstorage-sdk/issues/21) , Provides batch acquisition of data chunk hashes to reduce the number of network requests.

For small files like those on Vitalik's blog, the optimization doesn't significantly change the time taken. However, for larger files, the optimization provides a noticeable improvement.

larger file size: 3.9 MB  
Old: Time taken for `getChunkHash`: 0.464 minutes  
New: Time taken for `getChunkHashes`: 0.172 minutes


Additionally, we can encapsulate the parameters required before uploading a file into a single function, retrieving them all at once to reduce network requests.
`function getUploadInfo(bytes memory name) public override view returns (StorageMode mode, uint256 count, uint256 payment)`