### PR TITLE
Remove Unused Functions to Optimize Contract Bytecode Size

### DIFF
--- a/contracts/core/LargeStorageManager.sol
+++ b/contracts/core/LargeStorageManager.sol
@@ -61,22 +61,6 @@ contract LargeStorageManager {
         }
     }
 
-    function _putChunk(
-        bytes32 key,
-        uint256 chunkId,
-        bytes memory data,
-        uint256 value
-    ) internal {
-        _preparePut(key, chunkId, data.length);
-
-        // store data and rewrite metadata
-        if (data.length > SLOT_LIMIT) {
-            keyToMetadata[key][chunkId] = StorageHelper.putRaw(data, value).addrToBytes32();
-        } else {
-            keyToMetadata[key][chunkId] = SlotHelper.putRaw(keyToSlots[key][chunkId], data);
-        }
-    }
-
     function _getChunk(bytes32 key, uint256 chunkId) internal view returns (bytes memory, bool) {
         bytes32 metadata = keyToMetadata[key][chunkId];
 

--- a/contracts/libraries/StorageHelper.sol
+++ b/contracts/libraries/StorageHelper.sol
@@ -11,13 +11,6 @@ library StorageHelper {
     uint256 internal constant ADDR_OFF0 = 67;
     uint256 internal constant ADDR_OFF1 = 140;
 
-    // StorageSlotFactoryFromInput compiled via solc 0.8.7 optimized 200 + STORAGE_SLOT_CODE
-    bytes internal constant FACTORY_CODE =
-        hex"60806040526040516101113803806101118339810160408190526100229161002b565b80518060208301f35b6000602080838503121561003e57600080fd5b82516001600160401b038082111561005557600080fd5b818501915085601f83011261006957600080fd5b81518181111561007b5761007b6100fa565b604051601f8201601f19908116603f011681019083821181831017156100a3576100a36100fa565b8160405282815288868487010111156100bb57600080fd5b600093505b828410156100dd57848401860151818501870152928501926100c0565b828411156100ee5760008684830101525b98975050505050505050565b634e487b7160e01b600052604160045260246000fdfe000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000006080604052348015600f57600080fd5b506004361060325760003560e01c80632b68b9c61460375780638da5cb5b14603f575b600080fd5b603d6081565b005b60657f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b03909116815260200160405180910390f35b336001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000161460ed5760405162461bcd60e51b815260206004820152600e60248201526d3737ba10333937b69037bbb732b960911b604482015260640160405180910390fd5b33fffea2646970667358221220fc66c9afb7cb2f6209ae28167cf26c6c06f86a82cbe3c56de99027979389a1be64736f6c63430008070033";
-    uint256 internal constant FACTORY_SIZE_OFF = 305;
-    uint256 internal constant FACTORY_ADDR_OFF0 = 305 + 32 + ADDR_OFF0;
-    uint256 internal constant FACTORY_ADDR_OFF1 = 305 + 32 + ADDR_OFF1;
-
     function putRawFromCalldata(bytes calldata data, uint256 value) internal returns (address) {
         bytes memory bytecode = bytes.concat(STORAGE_SLOT_CODE, data);
         {
@@ -64,60 +57,6 @@ library StorageHelper {
 
         StorageSlotFactoryFromInput c = new StorageSlotFactoryFromInput{value: value}(bytecode);
         return address(c);
-    }
-
-    function putRaw2(
-        bytes32 key,
-        bytes memory data,
-        uint256 value
-    ) internal returns (address) {
-        // create the new contract code with the data
-        bytes memory bytecode = FACTORY_CODE;
-        uint256 bytecodeLen = bytecode.length;
-        uint256 newSize = bytecode.length + data.length;
-        assembly {
-            // in-place resize of bytecode bytes
-            // note that this must be done when bytecode is the last allocated object by solidity.
-            mstore(bytecode, newSize)
-            // notify solidity about the memory size increase, must be 32-bytes aligned
-            mstore(0x40, add(bytecode, and(add(add(newSize, 0x20), 0x1f), not(0x1f))))
-        }
-        // append data to self-destruct byte code
-        Memory.copy(Memory.dataPtr(data), Memory.dataPtr(bytecode) + bytecodeLen, data.length);
-        {
-            // revise the size of calldata
-            uint256 calldataSize = STORAGE_SLOT_CODE.length + data.length;
-            uint256 off = FACTORY_SIZE_OFF + 0x20;
-            assembly {
-                mstore(add(bytecode, off), calldataSize)
-            }
-        }
-        {
-            // revise the owner to the contract (so that it is destructable)
-            uint256 off = FACTORY_ADDR_OFF0 + 0x20;
-            assembly {
-                mstore(add(bytecode, off), address())
-            }
-            off = FACTORY_ADDR_OFF1 + 0x20;
-            assembly {
-                mstore(add(bytecode, off), address())
-            }
-        }
-
-        address addr;
-        assembly {
-            addr := create2(
-                value,
-                add(bytecode, 0x20), // data offset
-                mload(bytecode), // size
-                key
-            )
-
-            if iszero(extcodesize(addr)) {
-                revert(0, 0)
-            }
-        }
-        return addr;
     }
 
     function sizeRaw(address addr) internal view returns (uint256, bool) {
@@ -177,17 +116,5 @@ library StorageHelper {
             mstore(sub(content, 0x20), 0x20)
             return(sub(content, 0x20), size)
         }
-    }
-
-    function calculateValueForData(
-        uint256 datalen,
-        uint256 chunkSize,
-        uint256 codeStakingPerChunk
-    ) internal pure returns (uint256) {
-        return ((datalen + STORAGE_SLOT_CODE.length - 1) / chunkSize) * codeStakingPerChunk;
-    }
-
-    function storageSlotCodeLength() internal pure returns (uint256) {
-        return STORAGE_SLOT_CODE.length;
     }
 }

--- a/contracts/libraries/StorageSlotFactory.sol
+++ b/contracts/libraries/StorageSlotFactory.sol
@@ -1,44 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "./Memory.sol";
-
-// Create a storage slot by appending data to the end
-contract StorageSlotFromContract {
-    constructor(address contractAddr, bytes memory data) payable {
-        uint256 codeSize;
-        assembly {
-            // retrieve the size of the code, this needs assembly
-            codeSize := extcodesize(contractAddr)
-        }
-
-        uint256 totalSize = codeSize + data.length + 32;
-        bytes memory deployCode = new bytes(totalSize);
-
-        // Copy contract code
-        assembly {
-            // actually retrieve the code, this needs assembly
-            extcodecopy(contractAddr, add(deployCode, 0x20), 0, codeSize)
-        }
-
-        // Copy data
-        uint256 off = Memory.dataPtr(deployCode) + codeSize;
-        Memory.copy(Memory.dataPtr(data), off, data.length);
-
-        off += data.length;
-        uint256 len = data.length;
-        // Set data size
-        assembly {
-            mstore(off, len)
-        }
-
-        // Return the contract manually
-        assembly {
-            return(add(deployCode, 0x20), totalSize)
-        }
-    }
-}
-
 // Create a storage slot
 contract StorageSlotFactoryFromInput {
     constructor(bytes memory codeAndData) payable {


### PR DESCRIPTION
This pull request removes unused functions and related code from the smart contract, resulting in a significant reduction in the compiled bytecode size. This optimization helps improve contract deployment efficiency and can reduce gas costs.

Optimization Summary:

- Bytecode size before optimization: 46,846 hex characters
- Bytecode size after optimization: 31,618 hex characters